### PR TITLE
Remove SurfaceWithEdges & Align PyVista UI Controls 

### DIFF
--- a/pyvista_trame.py
+++ b/pyvista_trame.py
@@ -151,9 +151,17 @@ class VTKVisualizer:
         Sets the default parameters for the PyVista Plotter.
         """
         self.plotter.view_xy()
-        self.plotter.add_axes()
         self.plotter.show_grid()
-        
+
+        # Customize XYZ Axes Widget
+        self.plotter.add_axes(
+            line_width=5,
+            cone_radius=0.6,
+            shaft_length=0.7,
+            tip_length=0.3,
+            ambient=0.5,
+            label_size=(0.4, 0.16),
+        )
 
     def extract_data_arrays(self):
         """
@@ -197,17 +205,6 @@ class VTKVisualizer:
             cmap="rainbow",
         )
 
-        # Customize XYZ Axes Widget
-        self.plotter.add_axes(
-            line_width=5,
-            cone_radius=0.6,
-            shaft_length=0.7,
-            tip_length=0.3,
-            ambient=0.5,
-            label_size=(0.4, 0.16),
-        )
-
-        # Reset the camera to show the full objec
         self.plotter.reset_camera()
 
     def update_representation(self, mode):


### PR DESCRIPTION
## Description of Changes
- Removed option to switch to `SurfaceWithEdges` representation in dropdown.
  - Removed instances of manually turning on edges, as the default PyVista controls has a "Toggle Edge Visiblity" that the user can control.
- Right-aligned the `ui_controls` to the right of the header bar.
- Introduced various Vuetify CSS class styling to some text components (can change later).
- Added customizations to XYZ Axes Widget based on PyVista's [docs](https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotter.add_axes), makes said widget slightly more defined in appearence.
<img width="1121" alt="Screenshot 2024-06-26 at 5 19 41 PM" src="https://github.com/tgratek/ngstents_trame_visualizer/assets/79547648/0f610a3f-24d9-46df-93e7-c7a512a8b371">

