### PR TITLE
`PyVista` Fix improper color range mapping while dragging level slider

### DIFF
--- a/pyvista_trame.py
+++ b/pyvista_trame.py
@@ -284,9 +284,10 @@ class VTKVisualizer:
 
         self.plotter.remove_actor(self.zActor)
         
-        z_layer = self.mesh.threshold([self.default_min, z_value], scalars='tentlevel')
-        self.zActor = self.plotter.add_mesh(z_layer, scalars='tentlevel', cmap="rainbow", opacity=1, 
-                                            style=representation, show_edges=edges_enabled)
+        z_layer = self.mesh.threshold(value=(self.default_min, z_value), scalars='tentlevel')
+        self.zActor = self.plotter.add_mesh(z_layer, scalars='tentlevel', cmap='rainbow', opacity=1, 
+                                            style=representation, show_edges=edges_enabled,
+                                            clim=(self.default_min, self.default_max))
 
         self.update_representation(self.state.mesh_representation)
         self.plotter.render()


### PR DESCRIPTION
## Description of Changes
- Fixed a bug where dragging the level slider caused the color map to momentarily showcase the entire color bar range (e.g. in a `rainbow` map, purple to red) until the mouse was released. 
  - This "flash" of all the colors was distracting especially in the middle tent levels, as colors for higher levels (red) should not be shown.

## Testing
- On current `main` branch, in **remote rendering mode**, notice how holding down and dragging the level slider causes the entire rainbow `cmap` to briefly appear until the mouse is released, then the proper colors render depending on the tent level.
- On this branch, in **remote rendering mode,** dragging the level slider now maintains the expected color, and no flashing of other colors occur.
- _Although local mode is no longer the priority for this module, this technically fixes the same issue in that mode too, but the de-syncing and incorrect color scaling values still persist._